### PR TITLE
Update gunicorn timeout in production config

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ services:
   web:
     build: .
     command: >
-      sh -c "pixi run gunicorn --workers 9 --timeout 120"
+      sh -c "pixi run gunicorn --workers 9 --timeout 600"
     restart: always
     ports:
       - "80:8000"


### PR DESCRIPTION
Increased gunicorn timeout from 120 to 600 seconds.